### PR TITLE
kubectl: add --subresrouce status to edit command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -62,7 +62,10 @@ var (
 		kubectl edit job.v1.batch/myjob -o json
 
 		# Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation:
-		kubectl edit deployment/mydeployment -o yaml --save-config`))
+		kubectl edit deployment/mydeployment -o yaml --save-config
+		
+		# Edit the deployment/mydeployment's status subresource:
+		kubectl patch deployment mydeployment --subresource='status'`))
 )
 
 // NewCmdEdit creates the `edit` command
@@ -78,6 +81,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		Example:               editExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
+			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
 		},
 	}
@@ -94,5 +98,6 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		"Defaults to the line ending native to your platform.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-edit")
 	cmdutil.AddApplyAnnotationVarFlags(cmd, &o.ApplyAnnotation)
+	cmdutil.AddSubresourceFlags(cmd, &o.Subresource, "This is an 'alpha' flag. If specified, edit will operate on the subresource of the requested object.", cmdutil.StatusOnlySubresourceTypes)
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit_test.go
@@ -53,6 +53,7 @@ type EditTestCase struct {
 	Output           string   `yaml:"outputFormat"`
 	OutputPatch      string   `yaml:"outputPatch"`
 	SaveConfig       string   `yaml:"saveConfig"`
+	Subresource      string   `yaml:"subresource"`
 	Namespace        string   `yaml:"namespace"`
 	ExpectedStdout   []string `yaml:"expectedStdout"`
 	ExpectedStderr   []string `yaml:"expectedStderr"`
@@ -252,6 +253,9 @@ func TestEdit(t *testing.T) {
 			}
 			if len(testcase.SaveConfig) > 0 {
 				cmd.Flags().Set("save-config", testcase.SaveConfig)
+			}
+			if len(testcase.Subresource) > 0 {
+				cmd.Flags().Set("subresource", testcase.Subresource)
 			}
 
 			cmdutil.BehaviorOnFatal(func(str string, code int) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/0.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/0.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 3,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.edited
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.edited
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 4
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.original
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/1.original
@@ -1,0 +1,66 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: "2021-06-23T17:01:10Z"
+  generation: 5
+  labels:
+    app: nginx
+  name: nginx
+  namespace: edit-test
+  resourceVersion: "121107"
+  uid: a598ee47-9635-482b-bacb-16c9e3ade05c
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: nginx
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: gcr.io/kakaraparthy-devel/nginx:latest
+        imagePullPolicy: Always
+        name: nginx
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  availableReplicas: 3
+  conditions:
+  - lastTransitionTime: "2021-06-23T17:01:10Z"
+    lastUpdateTime: "2021-06-23T17:01:18Z"
+    message: ReplicaSet "nginx-6f5fdbd667" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  - lastTransitionTime: "2021-06-23T17:59:01Z"
+    lastUpdateTime: "2021-06-23T17:59:01Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  observedGeneration: 5
+  readyReplicas: 3
+  replicas: 3
+  updatedReplicas: 3

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.request
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.request
@@ -1,0 +1,5 @@
+{
+  "status": {
+    "replicas": 4
+  }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/2.response
@@ -1,0 +1,85 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+        "annotations": {
+            "deployment.kubernetes.io/revision": "1"
+        },
+        "creationTimestamp": "2021-06-23T17:01:10Z",
+        "generation": 5,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "nginx",
+        "namespace": "edit-test",
+        "resourceVersion": "121107",
+        "uid": "a598ee47-9635-482b-bacb-16c9e3ade05c"
+    },
+    "spec": {
+        "progressDeadlineSeconds": 600,
+        "replicas": 3,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": "25%",
+                "maxUnavailable": "25%"
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "gcr.io/kakaraparthy-devel/nginx:latest",
+                        "imagePullPolicy": "Always",
+                        "name": "nginx",
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    },
+    "status": {
+        "availableReplicas": 3,
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-06-23T17:01:10Z",
+                "lastUpdateTime": "2021-06-23T17:01:18Z",
+                "message": "ReplicaSet \"nginx-6f5fdbd667\" has successfully progressed.",
+                "reason": "NewReplicaSetAvailable",
+                "status": "True",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2021-06-23T17:59:01Z",
+                "lastUpdateTime": "2021-06-23T17:59:01Z",
+                "message": "Deployment has minimum availability.",
+                "reason": "MinimumReplicasAvailable",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "observedGeneration": 5,
+        "readyReplicas": 3,
+        "replicas": 4,
+        "updatedReplicas": 3
+    }
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/test.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-edit-subreource-status/test.yaml
@@ -1,0 +1,27 @@
+description: edit the status subresource
+mode: edit
+args:
+  - deployment
+  - nginx
+namespace: edit-test
+subresource: status
+expectedStdOut:
+  - deployment.apps/nginx edited
+expectedExitCode: 0
+steps:
+  - type: request
+    expectedMethod: GET
+    expectedPath: /apis/extensions/v1beta1/namespaces/edit-test/deployments/nginx/status
+    expectedInput: 0.request
+    resultingStatusCode: 200
+    resultingOutput: 0.response
+  - type: edit
+    expectedInput: 1.original
+    resultingOutput: 1.edited
+  - type: request
+    expectedMethod: PATCH
+    expectedPath: /apis/apps/v1/namespaces/edit-test/deployments/nginx/status
+    expectedContentType: application/strategic-merge-patch+json
+    expectedInput: 2.request
+    resultingStatusCode: 200
+    resultingOutput: 2.response

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -187,7 +187,7 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	addServerPrintColumnFlags(cmd, o)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
 	cmdutil.AddChunkSizeFlag(cmd, &o.ChunkSize)
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "This is an 'alpha' flag. If specified, gets the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "This is an 'alpha' flag. If specified, gets the subresource of the requested object.", cmdutil.SubresourceTypes)
 	return cmd
 }
 
@@ -322,7 +322,7 @@ func (o *GetOptions) Validate(cmd *cobra.Command) error {
 	if o.OutputWatchEvents && !(o.Watch || o.WatchOnly) {
 		return cmdutil.UsageErrorf(cmd, "--output-watch-events option can only be used with --watch or --watch-only")
 	}
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("get", o.subresource); err != nil {
 		return err
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -135,7 +135,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-patch")
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, patch will operate on the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, patch will operate on the subresource of the requested object.", cmdutil.SubresourceTypes)
 
 	return cmd
 }
@@ -195,7 +195,7 @@ func (o *PatchOptions) Validate() error {
 			return fmt.Errorf("--type must be one of %v, not %q", sets.StringKeySet(patchTypes).List(), o.PatchType)
 		}
 	}
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("patch", o.subresource); err != nil {
 		return err
 	}
 	return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -133,7 +133,7 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-replace")
-	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, replace will operate on the subresource of the requested object.")
+	cmdutil.AddSubresourceFlags(cmd, &o.subresource, "If specified, replace will operate on the subresource of the requested object.", cmdutil.SubresourceTypes)
 
 	return cmd
 }
@@ -240,7 +240,7 @@ func (o *ReplaceOptions) Validate(cmd *cobra.Command) error {
 		}
 	}
 
-	if err := cmdutil.IsValidSubresource(o.subresource); err != nil {
+	if err := cmdutil.IsValidSubresource("replace", o.subresource); err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -83,6 +83,8 @@ type EditOptions struct {
 	updatedResultGetter func(data []byte) *resource.Result
 
 	FieldManager string
+
+	Subresource string
 }
 
 // NewEditOptions returns an initialized EditOptions instance
@@ -183,6 +185,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 	}
 	r := b.NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		Subresource(o.Subresource).
 		ContinueOnError().
 		Flatten().
 		Do()
@@ -197,6 +200,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 		return f.NewBuilder().
 			Unstructured().
 			Stream(bytes.NewReader(data), "edited-file").
+			Subresource(o.Subresource).
 			ContinueOnError().
 			Flatten().
 			Do()
@@ -215,6 +219,9 @@ func (o *EditOptions) Complete(f cmdutil.Factory, args []string, cmd *cobra.Comm
 
 // Validate checks the EditOptions to see if there is sufficient information to run the command.
 func (o *EditOptions) Validate() error {
+	if err := cmdutil.IsValidSubresource("edit", o.Subresource); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -560,7 +567,7 @@ func (o *EditOptions) annotationPatch(update *resource.Info) error {
 	if err != nil {
 		return err
 	}
-	helper := resource.NewHelper(client, mapping).WithFieldManager(o.FieldManager)
+	helper := resource.NewHelper(client, mapping).WithFieldManager(o.FieldManager).WithSubresource(o.Subresource)
 	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch, nil)
 	if err != nil {
 		return err
@@ -692,7 +699,7 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 		}
 
 		patched, err := resource.NewHelper(info.Client, info.Mapping).
-			WithFieldManager(o.FieldManager).
+			WithFieldManager(o.FieldManager).WithSubresource(o.Subresource).
 			Patch(info.Namespace, info.Name, patchType, patch, nil)
 		if err != nil {
 			fmt.Fprintln(o.ErrOut, results.addError(err, info))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -461,8 +461,8 @@ func AddChunkSizeFlag(cmd *cobra.Command, value *int64) {
 		"Return large lists in chunks rather than all at once. Pass 0 to disable. This flag is beta and may change in the future.")
 }
 
-func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string) {
-	cmd.Flags().StringVar(subresource, "subresource", "", usage+fmt.Sprintf(" Must be one of %v. This flag is alpha and may change in the future.", subresourceTypes.List()))
+func AddSubresourceFlags(cmd *cobra.Command, subresource *string, usage string, allowedSubresoruces sets.String) {
+	cmd.Flags().StringVar(subresource, "subresource", "", usage+fmt.Sprintf(" Must be one of %v. This flag is alpha and may change in the future.", allowedSubresoruces.List()))
 }
 
 type ValidateOptions struct {
@@ -751,14 +751,24 @@ func Warning(cmdErr io.Writer, newGeneratorName, oldGeneratorName string) {
 	)
 }
 
-var subresourceTypes = sets.NewString("status", "scale")
+var SubresourceTypes = sets.NewString("status", "scale")
+var StatusOnlySubresourceTypes = sets.NewString("status")
 
-func IsValidSubresource(subresource string) error {
+func IsValidSubresource(cmd string, subresource string) error {
 	if len(subresource) == 0 {
 		return nil
 	}
-	if !subresourceTypes.Has(subresource) {
-		return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, subresourceTypes.List())
+	switch cmd {
+	case "get", "patch", "replace":
+		if !SubresourceTypes.Has(subresource) {
+			return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, SubresourceTypes.List())
+		}
+	case "edit":
+		if !StatusOnlySubresourceTypes.Has(subresource) {
+			return fmt.Errorf("invalid subresource value: %q. Must be one of %v", subresource, StatusOnlySubresourceTypes.List())
+		}
+	default:
+		return fmt.Errorf("subresource used with unsupported command '%v'", cmd)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -325,23 +325,33 @@ func TestDumpReaderToFile(t *testing.T) {
 func TestIsValidSubresource(t *testing.T) {
 	tests := []struct {
 		name        string
+		command     string
 		subresource string
 		isValid     bool
 	}{
 		{
 			name:        "Empty subresource - valid",
+			command:     "get",
 			subresource: "",
 			isValid:     true,
 		},
 		{
-			name:        "Scale subresource - valid",
+			name:        "Scale subresource with get - valid",
+			command:     "get",
 			subresource: "scale",
 			isValid:     true,
 		},
 		{
-			name:        "Status subresource - valid",
+			name:        "Status subresource with get - valid",
+			command:     "get",
 			subresource: "status",
 			isValid:     true,
+		},
+		{
+			name:        "Scale subresource with edit - invalid",
+			command:     "edit",
+			subresource: "scale",
+			isValid:     false,
 		},
 		{
 			name:        "invalid subresource - invalid",
@@ -351,7 +361,7 @@ func TestIsValidSubresource(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := IsValidSubresource(test.subresource)
+			actual := IsValidSubresource(test.command, test.subresource)
 			if (actual == nil) != test.isValid {
 				t.Errorf("expected subresoruce validity to be '%v', got '%v'", test.isValid, actual)
 			}


### PR DESCRIPTION
* Adds `--subresource` support to `edit` command. 
* Limits the support for status subresource.
* Adds unit tests for edit command
* Enhancements to unit tests of patch command